### PR TITLE
Add Firebase config for novel-site

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "novel-site-en"
+  }
+}

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,28 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install -g firebase-tools
+      - name: Install dependencies
+        run: |
+          cd docs-site
+          npm ci
+      - name: Build site
+        run: |
+          cd docs-site
+          npm run build
+      - name: Deploy to Firebase
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          firebase deploy --only hosting --token "$FIREBASE_TOKEN"

--- a/README.md
+++ b/README.md
@@ -45,3 +45,37 @@ npm run start
 This will launch a local development server so you can browse the documentation.
 
 The site navigation includes a link to the [NovaSaga repository](https://github.com/Wolfrine/NovaSaga).
+
+## Firebase Hosting
+
+This repository includes configuration for deploying the documentation site to
+Firebase Hosting. The GitHub Actions workflow in `.github/workflows` builds the
+`docs-site` directory and deploys it automatically when changes are pushed to
+`main`.
+
+1. Create a Firebase project and generate a deployment token:
+
+   ```bash
+   firebase login:ci
+   ```
+
+2. Add the token as `FIREBASE_TOKEN` in your repository secrets.
+3. The workflow will build and deploy the site to Firebase on every push to
+   `main`.
+
+The site will be available at `https://novel-site-en.web.app`.
+
+If you need to initialize Firebase in client-side scripts, use the configuration
+below:
+
+```javascript
+export const firebaseConfig = {
+  apiKey: "AIzaSyCedk5VIVtOL7qhLeVlPShuq22CmWUzcZM",
+  authDomain: "novel-site-en.firebaseapp.com",
+  projectId: "novel-site-en",
+  storageBucket: "novel-site-en.firebasestorage.app",
+  messagingSenderId: "970614384778",
+  appId: "1:970614384778:web:58cc844264bd2dfe11a573",
+  measurementId: "G-HYT3FX2Z45",
+};
+```

--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -10,8 +10,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'My Site',
-  tagline: 'Dinosaurs are cool',
+  title: 'NovaSaga',
+  tagline: 'Stories set in a growing universe',
   favicon:
     'https://raw.githubusercontent.com/facebook/docusaurus/main/website/static/img/favicon/favicon.ico',
 
@@ -21,15 +21,15 @@ const config = {
   },
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://novel-site-en.web.app',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: 'Wolfrine', // Usually your GitHub org/user name.
+  projectName: 'NovaSaga', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/docs-site/src/firebaseConfig.js
+++ b/docs-site/src/firebaseConfig.js
@@ -1,0 +1,9 @@
+export const firebaseConfig = {
+  apiKey: "AIzaSyCedk5VIVtOL7qhLeVlPShuq22CmWUzcZM",
+  authDomain: "novel-site-en.firebaseapp.com",
+  projectId: "novel-site-en",
+  storageBucket: "novel-site-en.firebasestorage.app",
+  messagingSenderId: "970614384778",
+  appId: "1:970614384778:web:58cc844264bd2dfe11a573",
+  measurementId: "G-HYT3FX2Z45",
+};

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,13 @@
+{
+  "hosting": {
+    "public": "docs-site/build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {"source": "**", "destination": "/index.html"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- set Firebase project ID to `novel-site-en`
- update Docusaurus URL to the Firebase host
- document Firebase configuration and provide sample snippet
- add `firebaseConfig.js` for optional client initialization

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68529fa2ddb8832e963ebc6254f6a242